### PR TITLE
Adding rangeSelect boolean flag

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -326,6 +326,7 @@
             filterBehavior: 'text',
             includeFilterClearBtn: true,
             preventInputChangeEvent: false,
+			rangeSelect: true,
             nonSelectedText: 'None selected',
             nSelectedText: 'selected',
             allSelectedText: 'All selected',
@@ -543,7 +544,7 @@
 
                 var $target = $(event.target);
                 
-                if (event.shiftKey && this.options.multiple) {
+                if (event.shiftKey && this.options.multiple && this.option.rangeSelect) {
                     if($target.is("label")){ // Handles checkbox selection manually (see https://github.com/davidstutz/bootstrap-multiselect/issues/431)
                         event.preventDefault();
                         $target = $target.find("input");


### PR DESCRIPTION
Adding rangeSelect boolean flag to allow users to enable/disable range selecting using the shift key. Without this option websites that are using the example "limit selectable inputs" method will have a bug where users can bypass the limit by using the shift key modifier while clicking on a disabled input.
